### PR TITLE
Install stm32plus and fwlib headers.

### DIFF
--- a/lib/SConscript
+++ b/lib/SConscript
@@ -40,6 +40,8 @@ libstm32plus=env.Library("stm32plus-"+VERSION+"-"+mcu+"-"+mode+".a",matches)
 # install the library if the user gave the install option
 
 env.Install(INSTALLDIR,libstm32plus)
+env.Install(INSTALLDIR,Dir("#lib/include"))
+env.Install(INSTALLDIR,Dir("#lib/fwlib"))
 env.Alias("install",INSTALLDIR)
 
 Return("libstm32plus")


### PR DESCRIPTION
This is the beginnings of making the install target produce a dev-style package, which includes pre-built static libraries as well as headers and build scripts necessary to link the library to a dependent project.

Two notes about this:
- This is a simplistic directory copy, and brings in the CMSIS and stdperiph sources as well as headers—not sure if there's a straightforward way to exclude those, short of enumerating which exact paths/files to include/exclude. Can env.Install accept an exclude glob or similar?
- Putting headers in /usr/lib/stm32plus is not correct by FHS.

I believe an FHS-compliant install target would do something like put the static library/libraries in `/usr/local/arm-none-eabi/lib` and the headers in `/usr/local/arm-none-eabi/include/stm32plus`. Any sources, build scripts, etc, would be placed in `/usr/local/arm-none-eabi/share`. If/when stm32plus is deb-packaged, the `/usr/local` paths would become `/usr`, as that is the correct path for things being installed and controlled by the packaging system as opposed to install scripts.

Anyhow, obviously this would be a breaking change for anybody currently using hardcoded paths or whatever, hence this PR just being the small first step of installing headers.
