### PR TITLE
Remove duplicate compiler flags

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -130,7 +130,7 @@ env.Append(CPPPATH=["#lib/include","#lib/include/stl","#lib"])
 # create the C and C++ flags that are needed. We can't use the extra or pedantic errors on the ST library code.
 
 env.Replace(CCFLAGS=["-Wall","-Werror","-ffunction-sections","-fdata-sections","-fno-exceptions","-mthumb","-gdwarf-2","-pipe"])
-env.Replace(CXXFLAGS=["-Wextra","-Werror","-pedantic-errors","-fno-rtti","-std=gnu++0x","-fno-threadsafe-statics","-pipe"])
+env.Replace(CXXFLAGS=["-Wextra","-pedantic-errors","-fno-rtti","-std=gnu++0x","-fno-threadsafe-statics"])
 env.Append(CCFLAGS="-DHSE_VALUE="+hse)
 env.Append(LINKFLAGS=["-Xlinker","--gc-sections","-mthumb","-g3","-gdwarf-2"])
 


### PR DESCRIPTION
CCFLAGS and CXXFLAGS both get passed to the C++ compiler, so eliminate duplicates between them.
