### PR TITLE
Fixed typename of non-member function slot

### DIFF
--- a/lib/include/event/slot.h
+++ b/lib/include/event/slot.h
@@ -55,7 +55,7 @@ namespace wink
     /// \note This function must be either marked as static, or not inside a class/struct (i.e. in global scope)
     static slot<Signature> bind(Signature fn)
     {
-      return slot_type(fn);
+      return __this_type(fn);
     }
     
     /// Binds a member function


### PR DESCRIPTION
Compilation fails when binding non-class-member function pointer.

```
In file included from ../../stm32plus/lib/include/config/event.h:24:0,
                 from ../../stm32plus/lib/include/config/dma.h:20,
                 from ../../stm32plus/lib/include/config/spi.h:19,
                 from quadruptor.cpp:3:
../../stm32plus/lib/include/event/slot.h: In instantiation of 'static wink::slot<Signature> wink::slot<Signature>::bind(Signature) [with Signature = void(stm32plus::UsartEventType)]':
quadruptor.cpp:64:56:   required from here
../../stm32plus/lib/include/event/slot.h:58:26: error: 'slot_type' was not declared in this scope
       return slot_type(fn);
                          ^
../../stm32plus/lib/include/event/slot.h: In static member function 'static wink::slot<Signature> wink::slot<Signature>::bind(Signature) [with Signature = void(stm32plus::UsartEventType)]':
../../stm32plus/lib/include/event/slot.h:59:5: warning: control reaches end of non-void function [-Wreturn-type]
     }
     ^
```

This PR should fix this issue.
