### PR TITLE
MillisecondTick event.

### DIFF
--- a/lib/include/timing/MillisecondTimer.h
+++ b/lib/include/timing/MillisecondTimer.h
@@ -6,12 +6,15 @@
 
 #pragma once
 
+#include "config/event.h"
+
 
 /**
  * The stm32plus namespace is the top-level namespace for all classes in the library.
  */
 
 namespace stm32plus {
+  DECLARE_EVENT_SIGNATURE(MillisecondTick,void());
 
   /**
    * @brief Millisecond delay counter using the SYSTICK core peripheral
@@ -30,6 +33,8 @@ namespace stm32plus {
       static bool hasTimedOut(uint32_t start,uint32_t timeout);
       static uint32_t difference(uint32_t start);
   };
+
+  extern DECLARE_EVENT_SOURCE(MillisecondTick);
 
 
   /**

--- a/lib/src/timing/MillisecondTimer.cpp
+++ b/lib/src/timing/MillisecondTimer.cpp
@@ -23,6 +23,8 @@ namespace stm32plus {
     _counter=0;
     SysTick_Config(SystemCoreClock / 1000);
   }
+
+  DECLARE_EVENT_SOURCE(MillisecondTick);
 }
 
 
@@ -33,5 +35,6 @@ namespace stm32plus {
 extern "C" {
   void __attribute__ ((interrupt("IRQ"))) SysTick_Handler(void) {
     stm32plus::MillisecondTimer::_counter++;
+    stm32plus::MillisecondTickEventSender.raiseEvent();
   }
 }


### PR DESCRIPTION
This change increases stm32plus's ability to coexist with other libraries needing a persistent 1ms notification. It uses the existing wink framework, adding a new event raised on a 1ms basis by the SysTick ISR.

This is related to #19, though there is definitely still an independent need for timeout functionality to be user-pluggable.
