### PR TITLE
Initialize linear buffer from void pointer.

### DIFF
--- a/lib/include/stream/BufferedInputOutputStream.h
+++ b/lib/include/stream/BufferedInputOutputStream.h
@@ -56,8 +56,8 @@ namespace stm32plus {
        * @param[in] size The size of the caller supplied buffer
        */
 
-      BufferedInputOutputStream(uint8_t *buffer,uint32_t size) {
-        _readPtr=_writePtr=_buffer=buffer;
+      BufferedInputOutputStream(void *buffer,uint32_t size) {
+        _readPtr=_writePtr=_buffer=static_cast<uint8_t*>(buffer);
         _bufferSize=size;
         _needToFree=false;
       }

--- a/lib/include/stream/LinearBufferInputOutputStream.h
+++ b/lib/include/stream/LinearBufferInputOutputStream.h
@@ -22,7 +22,7 @@ namespace stm32plus {
 
       // constructors
 
-      LinearBufferInputOutputStream(uint8_t *buffer,uint32_t size);
+      LinearBufferInputOutputStream(void *buffer,uint32_t size);
       LinearBufferInputOutputStream(uint32_t initialSize);
 
       void resetOutput();

--- a/lib/src/stream/LinearBufferInputOutputStream.cpp
+++ b/lib/src/stream/LinearBufferInputOutputStream.cpp
@@ -18,7 +18,7 @@ namespace stm32plus {
    * @param size
    */
 
-  LinearBufferInputOutputStream::LinearBufferInputOutputStream(uint8_t *buffer,uint32_t size)
+  LinearBufferInputOutputStream::LinearBufferInputOutputStream(void *buffer,uint32_t size)
     : BufferedInputOutputStream(buffer,size) {
   }
 


### PR DESCRIPTION
This is more flexible and avoids an unnecessary cast when interoperating with code which expects strings to be char arrays rather than unsigned char arrays.