### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/cmake/example/CMakeLists.txt
+++ b/cmake/example/CMakeLists.txt
@@ -1,10 +1,21 @@
 cmake_minimum_required(VERSION 2.8)
+
+# options
+set(MCU_BUILD_TYPE small)
+set(MCU_FAMILY f4)
+set(MCU_HSE 8000000)
+set(STM32_version 040100)
+
+
+# actual build
+set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
+set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
+
 set(CMAKE_PREFIX_PATH /usr/local/arm-none-eabi /usr/arm-none-eabi
   CACHE STRING "Library search paths")
 
-set(MCU_FAMILY f4)
-set(STM32PLUS_CONFIGURATION small-${MCU_FAMILY}-8000000-hard)
-find_package(stm32plus 030300 REQUIRED)
+set(STM32PLUS_CONFIGURATION ${MCU_BUILD_TYPE}-${MCU_FAMILY}-${MCU_HSE}-hard)
+find_package(stm32plus ${STM32_version REQUIRED)
 include_directories(${STM32PLUS_INCLUDE_DIRS})
 
 project(blink C CXX ASM)
@@ -17,6 +28,6 @@ add_executable(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME} ${STM32PLUS_LIBS})
 set_target_properties(${PROJECT_NAME} PROPERTIES
-  LINK_FLAGS "-T${PROJECT_SOURCE_DIR}/system/f4/Linker.ld")
+  LINK_FLAGS "-T${PROJECT_SOURCE_DIR}/system/${MCU_FAMILY}/Linker.ld")
 
 add_bin_target(${PROJECT_NAME})


### PR DESCRIPTION
I use cmake a lot and this is my current configuration. I find it a lot of besser to read and maintain.

The CMAKE_SHARED_LIBRARY_LINK_C{,XX}_FLAGS is needed, elsewise this will occur

    arm-none-eabi-g++: error: unrecognized command line option '-rdynamic'

see this thread http://stackoverflow.com/questions/10599038/can-i-skip-cmake-compiler-tests-or-avoid-error-unrecognized-option-rdynamic