### PR TITLE
Fix cmake example

### DIFF
--- a/cmake/example/CMakeLists.txt
+++ b/cmake/example/CMakeLists.txt
@@ -1,14 +1,20 @@
 cmake_minimum_required(VERSION 2.8)
+
+# Find stm32plus installed library.
 set(CMAKE_PREFIX_PATH /usr/local/arm-none-eabi /usr/arm-none-eabi
   CACHE STRING "Library search paths")
-
 set(MCU_FAMILY f4)
 set(STM32PLUS_CONFIGURATION small-${MCU_FAMILY}-8000000)
 find_package(stm32plus REQUIRED)
 include_directories(${STM32PLUS_INCLUDE_DIRS})
 
-project(blink C CXX ASM)
+# Suppress -rdynamic to the compiler. This should not be necessary
+# if your toolchain is gcc-arm-embedded.
+set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
+set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
+# Declare the project name and executable target.
+project(blink C CXX ASM)
 add_executable(${PROJECT_NAME}
   blink.cpp
   system/LibraryHacks.cpp
@@ -19,4 +25,5 @@ target_link_libraries(${PROJECT_NAME} ${STM32PLUS_LIBS})
 set_target_properties(${PROJECT_NAME} PROPERTIES
   LINK_FLAGS "-T${PROJECT_SOURCE_DIR}/system/${MCU_FAMILY}/Linker.ld")
 
+# Generate a bin file from GCC's elf output.
 add_bin_target(${PROJECT_NAME})

--- a/cmake/example/CMakeLists.txt
+++ b/cmake/example/CMakeLists.txt
@@ -3,8 +3,8 @@ set(CMAKE_PREFIX_PATH /usr/local/arm-none-eabi /usr/arm-none-eabi
   CACHE STRING "Library search paths")
 
 set(MCU_FAMILY f4)
-set(STM32PLUS_CONFIGURATION small-${MCU_FAMILY}-8000000-hard)
-find_package(stm32plus 030300 REQUIRED)
+set(STM32PLUS_CONFIGURATION small-${MCU_FAMILY}-8000000)
+find_package(stm32plus REQUIRED)
 include_directories(${STM32PLUS_INCLUDE_DIRS})
 
 project(blink C CXX ASM)
@@ -17,6 +17,6 @@ add_executable(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME} ${STM32PLUS_LIBS})
 set_target_properties(${PROJECT_NAME} PROPERTIES
-  LINK_FLAGS "-T${PROJECT_SOURCE_DIR}/system/f4/Linker.ld")
+  LINK_FLAGS "-T${PROJECT_SOURCE_DIR}/system/${MCU_FAMILY}/Linker.ld")
 
 add_bin_target(${PROJECT_NAME})


### PR DESCRIPTION
This PR is my suggested replacement for #102.

I have retained the -rdynamic removal, but avoided adding some of the other variables— I feel these are unnecessary and add unwanted indirection.

The build works correctly with the version number request simply left blank, so I have switched the example to use that approach.

@punkkeks Please review.