### PR TITLE
Update new

### DIFF
--- a/lib/include/stl/new
+++ b/lib/include/stl/new
@@ -8,6 +8,7 @@
 #ifndef __1F3E89E5_F35D_4f8d_A849_9A3416814905
 #define __1F3E89E5_F35D_4f8d_A849_9A3416814905
 
+#include <cstddef>
 
 void *operator new(std::size_t size_);
 void* operator new(std::size_t size_,void *ptr_);

--- a/lib/include/stl/new
+++ b/lib/include/stl/new
@@ -9,8 +9,8 @@
 #define __1F3E89E5_F35D_4f8d_A849_9A3416814905
 
 
-void *operator new(size_t size_);
-void* operator new(size_t size_,void *ptr_);
+void *operator new(std::size_t size_);
+void* operator new(std::size_t size_,void *ptr_);
 void operator delete(void *ptr_);
 
 


### PR DESCRIPTION
There are two minor issues here.
  1. The std is missing, so my compiler (arm-none-eabi-gcc (Arch Repository) 4.9.2 20150128 (prerelease)) won't compile anything, when I include <new> (std::size_t fixes this!)
  2. Some new/delete signatures are missing, like new[] or delete[]. Just check your default arm <new> include file 


```
/usr/local/arm-none-eabi/include/stm32plus-040100/stl/new:12:20: error: declaration of 'operator new' as non-function
void *operator new(size_t size_);
                   ^
/usr/local/arm-none-eabi/include/stm32plus-040100/stl/new:12:20: error: 'size_t' was not declared in this scope
```