### PR TITLE
Switch htons -> ntohs in UDP example

### DIFF
--- a/examples/net_udp_receive_async/net_udp_receive_async.cpp
+++ b/examples/net_udp_receive_async/net_udp_receive_async.cpp
@@ -208,7 +208,7 @@ class NetUdpReceiveAsyncTest {
 
       // the datagram length includes the UDP network header (8 bytes)
 
-      _datagramDataSize=NetUtil::htons(event.udpDatagram.udp_length)-UdpDatagram::getHeaderSize();
+      _datagramDataSize=NetUtil::ntohs(event.udpDatagram.udp_length)-UdpDatagram::getHeaderSize();
 
       // cut it down to a max of 10 bytes
 


### PR DESCRIPTION
Functionally identical, but I believe this is less confusing to a reader.