### PR TITLE
Default template argument issue in istream and ostream

### DIFF
--- a/lib/include/stl/istream
+++ b/lib/include/stl/istream
@@ -340,7 +340,7 @@ namespace std{
 
 	};
 	
-	template <class charT,class traits = char_traits<charT> > class _UCXXEXPORT basic_istream<charT,traits>::sentry {
+	template <class charT,class traits> class _UCXXEXPORT basic_istream<charT,traits>::sentry {
 		bool ok;
 	public:
 		explicit _UCXXEXPORT sentry(basic_istream<charT,traits>& os, bool noskipws = false){

--- a/lib/include/stl/ostream
+++ b/lib/include/stl/ostream
@@ -277,7 +277,7 @@ namespace std {
 #endif
 #endif
 
-	template <class charT,class traits = char_traits<charT> >
+	template <class charT,class traits>
 		class _UCXXEXPORT basic_ostream<charT,traits>::sentry
 	{
 		bool ok;


### PR DESCRIPTION
These default arguments will be inherited from `basic_ostream` and `basic_istream`.
Errors occur when compiling with newer toolchains (probably clang 3.5+, gcc 4.9+?).