### PR TITLE
Add __gnu_cxx::slist instead of std::slist

### DIFF
--- a/lib/include/config/event.h
+++ b/lib/include/config/event.h
@@ -15,9 +15,13 @@
  */
 
 // event depends on stl slist
-
+// some implementation contain slist in ext/slist
 #include "iterator"
-#include "slist"
+#ifdef EXT_SLIST
+    #include "ext/slist"
+#else
+    #include "slist"
+#endif
 
 // include the event/slot signal classes
 

--- a/lib/include/event/signal.h
+++ b/lib/include/event/signal.h
@@ -43,8 +43,11 @@ namespace wink {
       typedef Slot slot_type;
 
       slot_type _firstSlot;
+#ifdef EXT_SLIST     
+      __gnu_cxx::slist<slot_type> _slots;
+#else
       std::slist<slot_type> _slots;
-
+#endif
     public:
 
       /// Connects a slot to the signal


### PR DESCRIPTION
Slist include file is located in another directory and it is placed in another namespace in my toolchain's standard library (Windows version of arm-eabi). Since there's probably no way (or at least I wasn't able to find one) to automatically distinguish which namespace is the right one in compile time, I added a manuall switch. By defining preprocessor symbol "EXT_SLIST" the namespace and location of include file for slist is changed.

I think it migt be useful for other Windows users.