### PR TITLE
Fix compiler error in CharacterLcdTerminal

### DIFF
--- a/lib/include/display/character/CharacterLcdTerminal.h
+++ b/lib/include/display/character/CharacterLcdTerminal.h
@@ -286,7 +286,7 @@ namespace stm32plus {
     template<class TImpl>
     CharacterLcdTerminal<TImpl>& CharacterLcdTerminal<TImpl>::operator<<(double val) {
 
-      return operator<<(DoublePrecision(DoublePrecision::MAX_DOUBLE_FRACTION_DIGITS));
+      return operator<<(DoublePrecision(val, DoublePrecision::MAX_DOUBLE_FRACTION_DIGITS));
     }
 
     /**


### PR DESCRIPTION
You have to specify a val and a precision. Val was missing