### PR TITLE
Fix wrong delete operator for _buffer

### DIFF
--- a/lib/include/memory/circular_buffer.h
+++ b/lib/include/memory/circular_buffer.h
@@ -72,7 +72,7 @@ namespace stm32plus {
 
   template<typename T>
   inline circular_buffer<T>::~circular_buffer() {
-    delete _buffer;
+    delete[] _buffer;
   }
 
 


### PR DESCRIPTION
_buffer was allocated with new[ ], so it has to be deleted with delete[ ]