### PR TITLE
Delete forward declaration

### DIFF
--- a/lib/include/net/network/ip/InternetChecksum.h
+++ b/lib/include/net/network/ip/InternetChecksum.h
@@ -10,10 +10,6 @@
 namespace stm32plus {
   namespace net {
 
-    class IpPacketHeader;
-    class UdpDatagram;
-
-
     /**
      * Utility class to do the IP checksum algorithm
      */


### PR DESCRIPTION
Remove the declaration, because first it is a struct, not a class and second it is not needed for this headerfile.