### PR TITLE
include DacDmaWriterFeature in f0

### DIFF
--- a/lib/include/config/dma.h
+++ b/lib/include/config/dma.h
@@ -198,6 +198,7 @@
   #include "dma/features/f0/I2CDmaReaderFeature.h"
   #include "dma/features/f0/I2CDmaWriterFeature.h"
   #include "dma/features/f0/AdcDmaFeature.h"
+  #include "dma/features/f0/DacDmaWriterFeature.h"
 
   #include "dma/features/f0/DmaPeripheralInfo.h"
 

--- a/lib/include/config/dma.h
+++ b/lib/include/config/dma.h
@@ -199,7 +199,7 @@
   #include "dma/features/f0/I2CDmaWriterFeature.h"
   #include "dma/features/f0/AdcDmaFeature.h"
 
-#if !defined(STM32PLUS_F0_30)
+#if !(defined(STM32PLUS_F0_30) || defined(STM32PLUS_F0_42))
   #include "dma/features/f0/DacDmaWriterFeature.h"
 #endif
 

--- a/lib/include/config/dma.h
+++ b/lib/include/config/dma.h
@@ -198,7 +198,10 @@
   #include "dma/features/f0/I2CDmaReaderFeature.h"
   #include "dma/features/f0/I2CDmaWriterFeature.h"
   #include "dma/features/f0/AdcDmaFeature.h"
+
+#if !defined(STM32PLUS_F0_30)
   #include "dma/features/f0/DacDmaWriterFeature.h"
+#endif
 
   #include "dma/features/f0/DmaPeripheralInfo.h"
 

--- a/lib/include/dma/features/f0/DacDmaWriterFeature.h
+++ b/lib/include/dma/features/f0/DacDmaWriterFeature.h
@@ -27,7 +27,7 @@ namespace stm32plus {
    * @tparam TPriority One of the DMA priority constants. The default is |DMA_Priority_High|
    */
 
-  template<class TDacAlignmentFeature,uint32_t TPriority=DMA_Priority_High>
+  template<class TDacAlignmentFeature,uint32_t TPriority=DMA_Priority_High, uint32_t TMode=DMA_Mode_Normal>
   class DacDmaWriterFeature  : public DmaFeatureBase {
 
     public:
@@ -41,8 +41,8 @@ namespace stm32plus {
    * @param dma the base class reference
    */
 
-  template<class TDacAlignmentFeature,uint32_t TPriority>
-  inline DacDmaWriterFeature<TDacAlignmentFeature,TPriority>::DacDmaWriterFeature(Dma& dma)
+  template<class TDacAlignmentFeature,uint32_t TPriority,uint32_t TMode>
+  inline DacDmaWriterFeature<TDacAlignmentFeature,TPriority,TMode>::DacDmaWriterFeature(Dma& dma)
     : DmaFeatureBase(dma) {
 
     /*
@@ -116,7 +116,7 @@ namespace stm32plus {
     _init.DMA_DIR=DMA_DIR_PeripheralDST;                      // 'peripheral' is destination
     _init.DMA_PeripheralInc=DMA_PeripheralInc_Disable;        // 'peripheral' does not increment
     _init.DMA_MemoryInc=DMA_MemoryInc_Enable;                 // memory is incremented
-    _init.DMA_Mode=DMA_Mode_Normal;                           // not a circular buffer
+    _init.DMA_Mode=TMode;                           // not a circular buffer
     _init.DMA_Priority=TPriority;                             // user-configurable priority
     _init.DMA_M2M=DMA_M2M_Disable;                            // memory->peripheral configuration
   }
@@ -129,8 +129,8 @@ namespace stm32plus {
    * @param[in] count The number of bytes to transfer.
    */
 
-  template<class TDacAlignmentFeature,uint32_t TPriority>
-  inline void DacDmaWriterFeature<TDacAlignmentFeature,TPriority>::beginWrite(const void *source,uint32_t count) {
+  template<class TDacAlignmentFeature,uint32_t TPriority,uint32_t TMode>
+  inline void DacDmaWriterFeature<TDacAlignmentFeature,TPriority,TMode>::beginWrite(const void *source,uint32_t count) {
 
     DMA_Channel_TypeDef *peripheralAddress;
 

--- a/lib/include/dma/features/f0/DacDmaWriterFeature.h
+++ b/lib/include/dma/features/f0/DacDmaWriterFeature.h
@@ -130,7 +130,7 @@ namespace stm32plus {
    */
 
   template<class TDacAlignmentFeature,uint32_t TPriority>
-  inline void DacDmaWriterFeature<TTDacAlignmentFeature,TPriority>::beginWrite(const void *source,uint32_t count) {
+  inline void DacDmaWriterFeature<TDacAlignmentFeature,TPriority>::beginWrite(const void *source,uint32_t count) {
 
     DMA_Channel_TypeDef *peripheralAddress;
 


### PR DESCRIPTION
Trying to do DMA DAC on the STM32F051. It looks like this feature was written with a typo but not added to the config file.