### PR TITLE
don't re-initialize RTC if it survived a reboot (partial)

### DIFF
--- a/lib/include/gpio/GpioIterator.h
+++ b/lib/include/gpio/GpioIterator.h
@@ -26,7 +26,7 @@ namespace stm32plus {
    *
    *  This iterator is compatible with algorithms in the <algorithm> and <util/StdExt.h> header
    *  that take a forward iterator. In common with the STL iterators you are expected to
-   *  be digilent in checking the start and end position using begin() and end() because
+   *  be diligent in checking the start and end position using begin() and end() because
    *  the increment and decrement operators will not check for you.
    */
 

--- a/lib/include/rtc/Rtc.h
+++ b/lib/include/rtc/Rtc.h
@@ -18,7 +18,8 @@ namespace stm32plus {
               public Features... {
 
     public:
-      Rtc() :
+      Rtc(uint32_t hourFormat=RTC_HourFormat_24,uint32_t backupValue=BKP_MAGIC_VALUE) :
+        RtcBase(hourFormat, backupValue),
         Features(static_cast<RtcBase&>(*this))... {
       }
     };

--- a/lib/include/rtc/Rtc.h
+++ b/lib/include/rtc/Rtc.h
@@ -18,7 +18,7 @@ namespace stm32plus {
               public Features... {
 
     public:
-      Rtc(uint32_t hourFormat=RTC_HourFormat_24,uint32_t backupValue=BKP_MAGIC_VALUE) :
+      Rtc(uint32_t hourFormat=RTC_HourFormat_24,uint32_t backupValue=0) :
         RtcBase(hourFormat, backupValue),
         Features(static_cast<RtcBase&>(*this))... {
       }

--- a/lib/include/rtc/f0/RtcBase.h
+++ b/lib/include/rtc/f0/RtcBase.h
@@ -30,7 +30,7 @@ namespace stm32plus {
       uint32_t _hourFormat;
 
     public:
-      RtcBase(uint32_t hourFormat=RTC_HourFormat_24,uint32_t backupValue=BKP_MAGIC_VALUE);
+      RtcBase(uint32_t hourFormat=RTC_HourFormat_24,uint32_t backupValue=BKP_ALWAYS_RESET);
 
       void setTime(uint8_t hours,uint8_t minutes,uint8_t seconds,uint8_t am_pm=RTC_H12_AM) const;
       void getTime(uint8_t& hours,uint8_t& minutes,uint8_t& seconds,uint8_t& am_pm) const;

--- a/lib/include/rtc/f0/RtcBase.h
+++ b/lib/include/rtc/f0/RtcBase.h
@@ -20,16 +20,17 @@ namespace stm32plus {
 
   class RtcBase {
     enum {
-      BKP_VALUE = 0x70323373,         // To check if we have already initialised the RTC
-      SURVIVED_FLAG = 0x1000000,      // Stored in _hourFormat
-      HOUR_FORMAT_MASK = 0x0000ffff   // Values are 0 and 64
+      BKP_ALWAYS_RESET = 0,           // Old stm32plus behavior
+      BKP_MAGIC_VALUE = 0x70323373,   // To check if we have already initialised the RTC
+      NOT_SURVIVED_FLAG = 0x1000000,  // Stored in _hourFormat
+      HOUR_FORMAT_MASK = 0x0000ffff   // Hour format values are 0 and 64
     };
 
     protected:
       uint32_t _hourFormat;
 
     public:
-      RtcBase(uint32_t hourFormat=RTC_HourFormat_24);
+      RtcBase(uint32_t hourFormat=RTC_HourFormat_24,uint32_t backupValue=BKP_MAGIC_VALUE);
 
       void setTime(uint8_t hours,uint8_t minutes,uint8_t seconds,uint8_t am_pm=RTC_H12_AM) const;
       void getTime(uint8_t& hours,uint8_t& minutes,uint8_t& seconds,uint8_t& am_pm) const;
@@ -45,22 +46,27 @@ namespace stm32plus {
   };
 
   /**
-   * Constructor
+   * Constructor.
+   * If backupValue is non-zero, it is saved to RTC_BKP_DR0; the RTC will
+   * only be re-initialized if RTC_BKP_DR0 != backupValue.
    */
 
-  inline RtcBase::RtcBase(uint32_t hourFormat)
+  inline RtcBase::RtcBase(uint32_t hourFormat, uint32_t backupValue)
     : _hourFormat(hourFormat) {
 
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_PWR,ENABLE);
     PWR_BackupAccessCmd(ENABLE);          // allow backup domain access
 
-    if (RTC_ReadBackupRegister(RTC_BKP_DR0) != BKP_VALUE) {
+    // Ideally we would only set the backup value after configuring the LSE,
+    // and the number would depend on the chosen oscillator & settings.
+    // Otherwise re-flashing the firmware may not behave as expected.
+    if (backupValue == BKP_ALWAYS_RESET || RTC_ReadBackupRegister(RTC_BKP_DR0) != backupValue) {
       // reset the backup domain
       RCC_BackupResetCmd(ENABLE);
       RCC_BackupResetCmd(DISABLE);
 
-      RTC_WriteBackupRegister(RTC_BKP_DR0, BKP_VALUE);
-      _hourFormat |= SURVIVED_FLAG;
+      RTC_WriteBackupRegister(RTC_BKP_DR0, backupValue);
+      _hourFormat |= NOT_SURVIVED_FLAG;
     }
   }
 
@@ -160,12 +166,13 @@ namespace stm32plus {
   }
 
   /**
-   * Return whether the RTC configuration survived reset, used to decide
-   * whether we need to reset the backup domain or not.
+   * Return whether the RTC configuration survived reset, indicating
+   * whether the backup domain was reset or not.
+   * @return true if the RTC retained its configuration from a prior boot
    */
 
   inline bool RtcBase::survived() const {
-    return _hourFormat & SURVIVED_FLAG;
+    return !(_hourFormat & NOT_SURVIVED_FLAG);
   }
 
 

--- a/lib/include/rtc/features/f0/RtcLseClockFeature.h
+++ b/lib/include/rtc/features/f0/RtcLseClockFeature.h
@@ -34,6 +34,8 @@ namespace stm32plus {
   inline RtcLseClockFeature::RtcLseClockFeature(RtcBase& rtc)
     : RtcFeatureBase(rtc) {
 
+    if(rtc.survived()) { return; }  // already configured from earlier boot
+
     RTC_InitTypeDef init;
 
     // on with the LSE


### PR DESCRIPTION
Here's a concept implementation of the feature. If the magic value exists in the backup register, then we assume the RTC is still correctly configured. Based on the stdperiph example. Fixes #160 

Not tested yet and not completely elegant. I would like to have a way to change the BKP_VALUE to change so new firmware has a chance to reset the clock and I'm not entirely comfortable storing extra data in _hourFormat.