### PR TITLE
Make MillisecondTimer::delay weak

### DIFF
--- a/lib/include/timing/MillisecondTimer.h
+++ b/lib/include/timing/MillisecondTimer.h
@@ -24,7 +24,7 @@ namespace stm32plus {
 
     public:
       static void initialise();
-      static void delay(uint32_t millis_);
+      static void __attribute__ ((weak)) delay(uint32_t millis_);
       static uint32_t millis();
       static void reset();
       static bool hasTimedOut(uint32_t start,uint32_t timeout);
@@ -39,20 +39,6 @@ namespace stm32plus {
 
   inline uint32_t MillisecondTimer::millis() {
     return _counter;
-  }
-
-
-  /**
-   * Delay for given time. Waits for the current value of the systick counter to reach a target.
-   * @param millis The amount of time to wait.
-   */
-
-  inline void MillisecondTimer::delay(uint32_t millis) {
-
-    uint32_t target;
-
-    target=_counter+millis;
-    while(_counter<target);
   }
 
 

--- a/lib/src/timing/MillisecondTimer.cpp
+++ b/lib/src/timing/MillisecondTimer.cpp
@@ -23,6 +23,20 @@ namespace stm32plus {
     _counter=0;
     SysTick_Config(SystemCoreClock / 1000);
   }
+
+
+  /**
+   * Delay for given time. Waits for the current value of the systick counter to reach a target.
+   * @param millis The amount of time to wait.
+   */
+
+  inline void MillisecondTimer::delay(uint32_t millis) {
+
+    uint32_t target;
+
+    target=_counter+millis;
+    while(_counter<target);
+  }
 }
 
 


### PR DESCRIPTION
Made `MillisecondTimer::delay()` function have a weak attribute.
This will allow for those integrating with an RTOS to yield rather
than busy-wait. This solves issue #149.

Link time optimization seems to still support the `inline` of the function. Even though it needed to be moved to the `cpp` file to support the weak link attribute.