### PR TITLE
Fix misbehaving weak MillisecondTimer::delay function

### DIFF
--- a/lib/src/timing/MillisecondTimer.cpp
+++ b/lib/src/timing/MillisecondTimer.cpp
@@ -30,7 +30,7 @@ namespace stm32plus {
    * @param millis The amount of time to wait.
    */
 
-  inline void MillisecondTimer::delay(uint32_t millis) {
+  void MillisecondTimer::delay(uint32_t millis) {
 
     uint32_t target;
 


### PR DESCRIPTION
For some reason when I try this library with my compiler [arm-none-eabi-g++ (15:4.9.3+svn231177-1) 4.9.3 20150529 (prerelease)] and the cmake toolchain it seems to cause the delay() function to return immediately (perhaps because it links to the wrong thing). The inline keyword is not very useful anyway for a function defined in the cpp file.

The problem was introduced in pull request #169.