### PR TITLE
Include Adc2 in F1MD series.

### DIFF
--- a/lib/include/config/adc.h
+++ b/lib/include/config/adc.h
@@ -38,7 +38,7 @@
 
   // additional includes for the HD range
 
-  #if defined(STM32PLUS_F1_HD) || defined(STM32PLUS_F1_CL_E)
+  #if defined(STM32PLUS_F1_HD) || defined(STM32PLUS_F1_CL_E) || defined(STM32PLUS_F1_MD)
     #include "adc/Adc2.h"
   #endif
 


### PR DESCRIPTION
Nearly all F1 devices have 2 Adc peripherals. Therefore I added the Adc2 peripheral to F1MD series.