### PR TITLE
Add wrap=atexit to blinky project to reduce binary size #189

### DIFF
--- a/cmake/example/system/LibraryHacks.cpp
+++ b/cmake/example/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/adc_analog_watchdog/SConscript
+++ b/examples/adc_analog_watchdog/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/adc_analog_watchdog/system/LibraryHacks.cpp
+++ b/examples/adc_analog_watchdog/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/adc_multi_dma_multichan/SConscript
+++ b/examples/adc_multi_dma_multichan/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/adc_multi_dma_multichan/system/LibraryHacks.cpp
+++ b/examples/adc_multi_dma_multichan/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/adc_single/SConscript
+++ b/examples/adc_single/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/adc_single/system/LibraryHacks.cpp
+++ b/examples/adc_single/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/adc_single_dma_multichan/SConscript
+++ b/examples/adc_single_dma_multichan/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/adc_single_dma_multichan/system/LibraryHacks.cpp
+++ b/examples/adc_single_dma_multichan/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/adc_single_injected/SConscript
+++ b/examples/adc_single_injected/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/adc_single_injected/system/LibraryHacks.cpp
+++ b/examples/adc_single_injected/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/adc_single_interrupts/SConscript
+++ b/examples/adc_single_interrupts/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/adc_single_interrupts/system/LibraryHacks.cpp
+++ b/examples/adc_single_interrupts/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/adc_single_timer_interrupts/SConscript
+++ b/examples/adc_single_timer_interrupts/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/adc_single_timer_interrupts/system/LibraryHacks.cpp
+++ b/examples/adc_single_timer_interrupts/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/ads7843/SConscript
+++ b/examples/ads7843/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/ads7843/system/LibraryHacks.cpp
+++ b/examples/ads7843/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/blink/SConscript
+++ b/examples/blink/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/blink/system/LibraryHacks.cpp
+++ b/examples/blink/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/button/SConscript
+++ b/examples/button/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/button/system/LibraryHacks.cpp
+++ b/examples/button/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/can_master_send_receive/SConscript
+++ b/examples/can_master_send_receive/SConscript
@@ -79,7 +79,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/can_master_send_receive/system/LibraryHacks.cpp
+++ b/examples/can_master_send_receive/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/crc/SConscript
+++ b/examples/crc/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/crc/system/LibraryHacks.cpp
+++ b/examples/crc/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/cs43l22_beep/SConscript
+++ b/examples/cs43l22_beep/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/cs43l22_beep/system/LibraryHacks.cpp
+++ b/examples/cs43l22_beep/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/dac_noise/SConscript
+++ b/examples/dac_noise/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/dac_noise/system/LibraryHacks.cpp
+++ b/examples/dac_noise/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/dac_triangle/SConscript
+++ b/examples/dac_triangle/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/dac_triangle/system/LibraryHacks.cpp
+++ b/examples/dac_triangle/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/debug_semihosting/system/LibraryHacks.cpp
+++ b/examples/debug_semihosting/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/dma_copy/SConscript
+++ b/examples/dma_copy/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/dma_copy/system/LibraryHacks.cpp
+++ b/examples/dma_copy/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/dma_fill/SConscript
+++ b/examples/dma_fill/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/dma_fill/system/LibraryHacks.cpp
+++ b/examples/dma_fill/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/exti/SConscript
+++ b/examples/exti/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/exti/system/LibraryHacks.cpp
+++ b/examples/exti/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/fatfs_iterate/SConscript
+++ b/examples/fatfs_iterate/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/fatfs_iterate/system/LibraryHacks.cpp
+++ b/examples/fatfs_iterate/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/fatfs_reader/SConscript
+++ b/examples/fatfs_reader/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/fatfs_reader/system/LibraryHacks.cpp
+++ b/examples/fatfs_reader/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/fatfs_writer/SConscript
+++ b/examples/fatfs_writer/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/fatfs_writer/system/LibraryHacks.cpp
+++ b/examples/fatfs_writer/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/flash_internal_settings/SConscript
+++ b/examples/flash_internal_settings/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/flash_internal_settings/system/LibraryHacks.cpp
+++ b/examples/flash_internal_settings/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/flash_spi_program/SConscript
+++ b/examples/flash_spi_program/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/flash_spi_program/system/LibraryHacks.cpp
+++ b/examples/flash_spi_program/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/flash_spi_reader/SConscript
+++ b/examples/flash_spi_reader/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/flash_spi_reader/system/LibraryHacks.cpp
+++ b/examples/flash_spi_reader/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/fsmc_sram/SConscript
+++ b/examples/fsmc_sram/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/fsmc_sram/system/LibraryHacks.cpp
+++ b/examples/fsmc_sram/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/hd44780/SConscript
+++ b/examples/hd44780/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/hd44780/system/LibraryHacks.cpp
+++ b/examples/hd44780/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/hx8347a/SConscript
+++ b/examples/hx8347a/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/hx8347a/system/LibraryHacks.cpp
+++ b/examples/hx8347a/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/hx8352a/SConscript
+++ b/examples/hx8352a/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/hx8352a/system/LibraryHacks.cpp
+++ b/examples/hx8352a/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/hx8352a_gpio/SConscript
+++ b/examples/hx8352a_gpio/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/hx8352a_gpio/system/LibraryHacks.cpp
+++ b/examples/hx8352a_gpio/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/i2c_at24c32/SConscript
+++ b/examples/i2c_at24c32/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/i2c_at24c32/system/LibraryHacks.cpp
+++ b/examples/i2c_at24c32/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/i2c_cs43l22/SConscript
+++ b/examples/i2c_cs43l22/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/i2c_cs43l22/system/LibraryHacks.cpp
+++ b/examples/i2c_cs43l22/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/ili9325/SConscript
+++ b/examples/ili9325/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/ili9325/system/LibraryHacks.cpp
+++ b/examples/ili9325/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/ili9327/SConscript
+++ b/examples/ili9327/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/ili9327/system/LibraryHacks.cpp
+++ b/examples/ili9327/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/ili9481/SConscript
+++ b/examples/ili9481/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/ili9481/system/LibraryHacks.cpp
+++ b/examples/ili9481/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/lds285/SConscript
+++ b/examples/lds285/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/lds285/system/LibraryHacks.cpp
+++ b/examples/lds285/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/lgdp453x/SConscript
+++ b/examples/lgdp453x/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/lgdp453x/system/LibraryHacks.cpp
+++ b/examples/lgdp453x/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/mc2pa8201/SConscript
+++ b/examples/mc2pa8201/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/mc2pa8201/system/LibraryHacks.cpp
+++ b/examples/mc2pa8201/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_dhcp/SConscript
+++ b/examples/net_dhcp/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_dhcp/system/LibraryHacks.cpp
+++ b/examples/net_dhcp/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_dns/SConscript
+++ b/examples/net_dns/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_dns/system/LibraryHacks.cpp
+++ b/examples/net_dns/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_ftp_server/SConscript
+++ b/examples/net_ftp_server/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_ftp_server/system/LibraryHacks.cpp
+++ b/examples/net_ftp_server/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_llip/SConscript
+++ b/examples/net_llip/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_llip/system/LibraryHacks.cpp
+++ b/examples/net_llip/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_ping_client/SConscript
+++ b/examples/net_ping_client/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_ping_client/system/LibraryHacks.cpp
+++ b/examples/net_ping_client/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_tcp_client/SConscript
+++ b/examples/net_tcp_client/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_tcp_client/system/LibraryHacks.cpp
+++ b/examples/net_tcp_client/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_tcp_client_async/SConscript
+++ b/examples/net_tcp_client_async/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_tcp_client_async/system/LibraryHacks.cpp
+++ b/examples/net_tcp_client_async/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_tcp_server/SConscript
+++ b/examples/net_tcp_server/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_tcp_server/system/LibraryHacks.cpp
+++ b/examples/net_tcp_server/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_udp_receive/SConscript
+++ b/examples/net_udp_receive/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_udp_receive/system/LibraryHacks.cpp
+++ b/examples/net_udp_receive/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_udp_receive_async/SConscript
+++ b/examples/net_udp_receive_async/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_udp_receive_async/system/LibraryHacks.cpp
+++ b/examples/net_udp_receive_async/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_udp_send/SConscript
+++ b/examples/net_udp_send/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_udp_send/system/LibraryHacks.cpp
+++ b/examples/net_udp_send/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_web_client/SConscript
+++ b/examples/net_web_client/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_web_client/system/LibraryHacks.cpp
+++ b/examples/net_web_client/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_web_pframe/SConscript
+++ b/examples/net_web_pframe/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_web_pframe/system/LibraryHacks.cpp
+++ b/examples/net_web_pframe/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/net_web_server/SConscript
+++ b/examples/net_web_server/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/net_web_server/system/LibraryHacks.cpp
+++ b/examples/net_web_server/system/LibraryHacks.cpp
@@ -110,4 +110,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/pframe/SConscript
+++ b/examples/pframe/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/pframe/system/LibraryHacks.cpp
+++ b/examples/pframe/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/power/SConscript
+++ b/examples/power/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/power/system/LibraryHacks.cpp
+++ b/examples/power/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/r61523/SConscript
+++ b/examples/r61523/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/r61523/system/LibraryHacks.cpp
+++ b/examples/r61523/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/r61523_f051/SConscript
+++ b/examples/r61523_f051/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/r61523_f051/system/LibraryHacks.cpp
+++ b/examples/r61523_f051/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/r61523_mdvl/SConscript
+++ b/examples/r61523_mdvl/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/r61523_mdvl/system/LibraryHacks.cpp
+++ b/examples/r61523_mdvl/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/rtc/SConscript
+++ b/examples/rtc/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/rtc/system/LibraryHacks.cpp
+++ b/examples/rtc/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/sdio/SConscript
+++ b/examples/sdio/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/sdio/system/LibraryHacks.cpp
+++ b/examples/sdio/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/spi_send_dma/SConscript
+++ b/examples/spi_send_dma/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/spi_send_dma/system/LibraryHacks.cpp
+++ b/examples/spi_send_dma/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/spi_send_interrupts/SConscript
+++ b/examples/spi_send_interrupts/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/spi_send_interrupts/system/LibraryHacks.cpp
+++ b/examples/spi_send_interrupts/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/spi_send_sync/SConscript
+++ b/examples/spi_send_sync/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/spi_send_sync/system/LibraryHacks.cpp
+++ b/examples/spi_send_sync/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/ssd1289/SConscript
+++ b/examples/ssd1289/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/ssd1289/system/LibraryHacks.cpp
+++ b/examples/ssd1289/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/ssd1963/SConscript
+++ b/examples/ssd1963/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/ssd1963/system/LibraryHacks.cpp
+++ b/examples/ssd1963/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/st7783/SConscript
+++ b/examples/st7783/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/st7783/system/LibraryHacks.cpp
+++ b/examples/st7783/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_dma_pwm/SConscript
+++ b/examples/timer_dma_pwm/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_dma_pwm/system/LibraryHacks.cpp
+++ b/examples/timer_dma_pwm/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_dma_usart/SConscript
+++ b/examples/timer_dma_usart/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_dma_usart/system/LibraryHacks.cpp
+++ b/examples/timer_dma_usart/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_dual_gpio_out/SConscript
+++ b/examples/timer_dual_gpio_out/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_dual_gpio_out/system/LibraryHacks.cpp
+++ b/examples/timer_dual_gpio_out/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_dual_pwm_gpio_out/SConscript
+++ b/examples/timer_dual_pwm_gpio_out/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_dual_pwm_gpio_out/system/LibraryHacks.cpp
+++ b/examples/timer_dual_pwm_gpio_out/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_encoder/SConscript
+++ b/examples/timer_encoder/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_encoder/system/LibraryHacks.cpp
+++ b/examples/timer_encoder/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_gpio_out/SConscript
+++ b/examples/timer_gpio_out/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_gpio_out/system/LibraryHacks.cpp
+++ b/examples/timer_gpio_out/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_input_capture/SConscript
+++ b/examples/timer_input_capture/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_input_capture/system/LibraryHacks.cpp
+++ b/examples/timer_input_capture/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_interrupts/SConscript
+++ b/examples/timer_interrupts/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_interrupts/system/LibraryHacks.cpp
+++ b/examples/timer_interrupts/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_master_slave/SConscript
+++ b/examples/timer_master_slave/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_master_slave/system/LibraryHacks.cpp
+++ b/examples/timer_master_slave/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_pwm_break/SConscript
+++ b/examples/timer_pwm_break/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_pwm_break/system/LibraryHacks.cpp
+++ b/examples/timer_pwm_break/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/timer_pwm_gpio_out/SConscript
+++ b/examples/timer_pwm_gpio_out/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/timer_pwm_gpio_out/system/LibraryHacks.cpp
+++ b/examples/timer_pwm_gpio_out/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usart_receive_dma/SConscript
+++ b/examples/usart_receive_dma/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usart_receive_dma/system/LibraryHacks.cpp
+++ b/examples/usart_receive_dma/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usart_receive_interrupts/SConscript
+++ b/examples/usart_receive_interrupts/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usart_receive_interrupts/system/LibraryHacks.cpp
+++ b/examples/usart_receive_interrupts/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usart_receive_sync/SConscript
+++ b/examples/usart_receive_sync/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usart_receive_sync/system/LibraryHacks.cpp
+++ b/examples/usart_receive_sync/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usart_send_dma/SConscript
+++ b/examples/usart_send_dma/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usart_send_dma/system/LibraryHacks.cpp
+++ b/examples/usart_send_dma/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usart_send_dma_interrupts/SConscript
+++ b/examples/usart_send_dma_interrupts/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usart_send_dma_interrupts/system/LibraryHacks.cpp
+++ b/examples/usart_send_dma_interrupts/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usart_send_interrupts/SConscript
+++ b/examples/usart_send_interrupts/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usart_send_interrupts/system/LibraryHacks.cpp
+++ b/examples/usart_send_interrupts/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usart_send_sync/SConscript
+++ b/examples/usart_send_sync/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usart_send_sync/system/LibraryHacks.cpp
+++ b/examples/usart_send_sync/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usb_device_cdc_com_port/SConscript
+++ b/examples/usb_device_cdc_com_port/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usb_device_cdc_com_port/system/LibraryHacks.cpp
+++ b/examples/usb_device_cdc_com_port/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usb_device_f0_custom_hid/SConscript
+++ b/examples/usb_device_f0_custom_hid/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usb_device_f0_custom_hid/system/LibraryHacks.cpp
+++ b/examples/usb_device_f0_custom_hid/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usb_device_hid_custom_adc/SConscript
+++ b/examples/usb_device_hid_custom_adc/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usb_device_hid_custom_adc/system/LibraryHacks.cpp
+++ b/examples/usb_device_hid_custom_adc/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usb_device_hid_keyboard/SConscript
+++ b/examples/usb_device_hid_keyboard/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usb_device_hid_keyboard/system/LibraryHacks.cpp
+++ b/examples/usb_device_hid_keyboard/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usb_device_hid_mouse/SConscript
+++ b/examples/usb_device_hid_mouse/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usb_device_hid_mouse/system/LibraryHacks.cpp
+++ b/examples/usb_device_hid_mouse/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usb_device_msc_internal/SConscript
+++ b/examples/usb_device_msc_internal/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usb_device_msc_internal/system/LibraryHacks.cpp
+++ b/examples/usb_device_msc_internal/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }

--- a/examples/usb_device_msc_sdcard/SConscript
+++ b/examples/usb_device_msc_sdcard/SConscript
@@ -84,7 +84,7 @@ if supported:
 
   # set the additional linker flags
 
-  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2"])
+  env.Append(LINKFLAGS=["-T"+linkerscript,"-Wl,-wrap,__aeabi_unwind_cpp_pr0","-Wl,-wrap,__aeabi_unwind_cpp_pr1","-Wl,-wrap,__aeabi_unwind_cpp_pr2","-Wl,-wrap,atexit"])
 
   # additional include directory for the graphics
 

--- a/examples/usb_device_msc_sdcard/system/LibraryHacks.cpp
+++ b/examples/usb_device_msc_sdcard/system/LibraryHacks.cpp
@@ -92,4 +92,8 @@ extern "C" {
 
     return (caddr_t) prev_heap;
   }
+
+  int __wrap_atexit (void (*)(void)) {
+         return 0;
+  }
 }


### PR DESCRIPTION
Adding atexit wrap here. Same changes would need to be added to .cproject files.
Should i just copy the same change over to all sample projects, or are these somehow automatically synced ?