### PR TITLE
Fix warning of `inline` and `__attribute__((noinline))` collision

### DIFF
--- a/lib/include/display/graphic/access/Gpio16BitAccessMode_64K_24_80_80.h
+++ b/lib/include/display/graphic/access/Gpio16BitAccessMode_64K_24_80_80.h
@@ -203,7 +203,7 @@ namespace stm32plus {
      */
 
     template<class TPinPackage>
-    __attribute__((noinline)) inline void Gpio16BitAccessMode<TPinPackage,COLOURS_16BIT,24,80,80>::writeMultiData(uint32_t howMuch,uint16_t value) const {
+	void Gpio16BitAccessMode<TPinPackage,COLOURS_16BIT,24,80,80>::writeMultiData(uint32_t howMuch,uint16_t value) const {
 
       __asm volatile(
           "    str  %[value],   [%[data]]                 \n\t"     // port <= value

--- a/lib/include/display/graphic/access/Gpio16BitAccessMode_64K_48_42_42.h
+++ b/lib/include/display/graphic/access/Gpio16BitAccessMode_64K_48_42_42.h
@@ -202,7 +202,7 @@ namespace stm32plus {
      */
 
     template<class TPinPackage>
-    __attribute__((noinline)) inline void Gpio16BitAccessMode<TPinPackage,COLOURS_16BIT,48,42,42>::writeMultiData(uint32_t howMuch,uint16_t value) const {
+	void Gpio16BitAccessMode<TPinPackage,COLOURS_16BIT,48,42,42>::writeMultiData(uint32_t howMuch,uint16_t value) const {
 
       // F0 compatibility : value, data, rs are only needed at the start so move
       // them to own asm section so gcc doesn't have to find so many registers


### PR DESCRIPTION
Fix warning appeared on fresh GCC 7.2.1 because of the conflict between `inline` and `__attribute__((noinline))` specified for the same function. Since the project is built with `-Werror` that fails the compilation.

Please, feel free to inform me or edit the patch, if I resolved these opposite inline declarations the wrong way.