### PR TITLE
Cmake fixes

### DIFF
--- a/cmake/stm32plus-config-specific.cmake.in
+++ b/cmake/stm32plus-config-specific.cmake.in
@@ -11,7 +11,7 @@ set(CMAKE_EXE_LINKER_FLAGS "%(LINKFLAGS)s" CACHE INTERNAL "executable linker fla
 set(CMAKE_MODULE_LINKER_FLAGS "%(LINKFLAGS)s" CACHE INTERNAL "module linker flags")
 set(CMAKE_SHARED_LINKER_FLAGS "%(LINKFLAGS)s" CACHE INTERNAL "shared linker flags")
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-wrap,__aeabi_unwind_cpp_pr0 -Wl,-wrap,__aeabi_unwind_cpp_pr1 -Wl,-wrap,__aeabi_unwind_cpp_pr2")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-wrap,__aeabi_unwind_cpp_pr0 -Wl,-wrap,__aeabi_unwind_cpp_pr1 -Wl,-wrap,__aeabi_unwind_cpp_pr2 -Wl,-wrap,atexit")
 
 set(CMAKE_C_COMPILER %(CC)s)
 set(CMAKE_CXX_COMPILER (%(CXX)s)

--- a/cmake/stm32plus-config-specific.cmake.in
+++ b/cmake/stm32plus-config-specific.cmake.in
@@ -13,8 +13,8 @@ set(CMAKE_SHARED_LINKER_FLAGS "%(LINKFLAGS)s" CACHE INTERNAL "shared linker flag
 
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-wrap,__aeabi_unwind_cpp_pr0 -Wl,-wrap,__aeabi_unwind_cpp_pr1 -Wl,-wrap,__aeabi_unwind_cpp_pr2")
 
-cmake_force_c_compiler(%(CC)s GNU)
-cmake_force_cxx_compiler(%(CXX)s GNU)
+set(CMAKE_C_COMPILER %(CC)s)
+set(CMAKE_CXX_COMPILER (%(CXX)s)
 set(CMAKE_ASM_COMPILER %(CC)s)
 set(CMAKE_OBJCOPY arm-none-eabi-objcopy CACHE INTERNAL "objcopy tool")
 set(CMAKE_OBJDUMP arm-none-eabi-objdump CACHE INTERNAL "objdump tool")


### PR DESCRIPTION
Fix a couple of issues with building cmake example against stm32plus installation with recent versions of CMake (tested with 3.8.1).