### PR TITLE
docs: fix simple typo, thrsholds -> thresholds

### DIFF
--- a/lib/fwlib/f0/stdperiph/src/stm32f0xx_adc.c
+++ b/lib/fwlib/f0/stdperiph/src/stm32f0xx_adc.c
@@ -1030,7 +1030,7 @@ void ADC_DMARequestModeConfig(ADC_TypeDef* ADCx, uint32_t ADC_DMARequestMode)
     [..]
         (+)Flags :
            (##) ADC_FLAG_AWD: This flag is set by hardware when the converted
-                voltage crosses the values programmed thrsholds
+                voltage crosses the values programmed thresholds
 
         (+)Interrupts :
            (##) ADC_IT_AWD : specifies the interrupt source for Analog watchdog 


### PR DESCRIPTION
There is a small typo in lib/fwlib/f0/stdperiph/src/stm32f0xx_adc.c.

Should read `thresholds` rather than `thrsholds`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md