### PR TITLE
Updated define for AdcInterruptFeature to avoid conflict with math.h …

### DIFF
--- a/lib/include/adc/features/f0/AdcInterruptFeature.h
+++ b/lib/include/adc/features/f0/AdcInterruptFeature.h
@@ -41,7 +41,7 @@ namespace stm32plus {
     public:
       enum {
         END_OF_CONVERSION = 0x01,
-        OVERFLOW          = 0x02,
+        ADC_OVERFLOW      = 0x02,
         END_OF_SEQUENCE   = 0x04,
         ANALOG_WATCHDOG   = 0x08,
         END_OF_SAMPLING   = 0x10,
@@ -93,7 +93,7 @@ namespace stm32plus {
 
   /**
    * Enable the interrupts specified in the mask
-   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | OVERFLOW
+   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | ADC_OVERFLOW
    */
 
   inline void AdcInterruptFeature::enableInterrupts(uint16_t interruptMask) {
@@ -114,7 +114,7 @@ namespace stm32plus {
       ADC_ITConfig(_adc,ADC_IT_EOSMP,ENABLE);
     if((interruptMask & ANALOG_WATCHDOG)!=0)
       ADC_ITConfig(_adc,ADC_IT_AWD,ENABLE);
-    if((interruptMask & OVERFLOW)!=0)
+    if((interruptMask & ADC_OVERFLOW)!=0)
       ADC_ITConfig(_adc,ADC_IT_OVR,ENABLE);
     if((interruptMask & ADC_READY)!=0)
       ADC_ITConfig(_adc,ADC_IT_ADRDY,ENABLE);
@@ -123,7 +123,7 @@ namespace stm32plus {
 
   /**
    * Disable the interrupts specified in the mask
-   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | OVERFLOW
+   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | ADC_OVERFLOW
    */
 
   inline void AdcInterruptFeature::disableInterrupts(uint16_t interruptMask) {
@@ -137,7 +137,7 @@ namespace stm32plus {
       ADC_ITConfig(_adc,ADC_IT_EOSMP,DISABLE);
     if((interruptMask & ANALOG_WATCHDOG)!=0)
       ADC_ITConfig(_adc,ADC_IT_AWD,DISABLE);
-    if((interruptMask & OVERFLOW)!=0)
+    if((interruptMask & ADC_OVERFLOW)!=0)
       ADC_ITConfig(_adc,ADC_IT_OVR,DISABLE);
     if((interruptMask & ADC_READY)!=0)
       ADC_ITConfig(_adc,ADC_IT_ADRDY,DISABLE);

--- a/lib/include/adc/features/f1/AdcInterruptFeature.h
+++ b/lib/include/adc/features/f1/AdcInterruptFeature.h
@@ -95,7 +95,7 @@ namespace stm32plus {
 
   /**
    * Enable the interrupts specified in the mask
-   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | OVERFLOW
+   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | ADC_OVERFLOW
    */
 
   inline void AdcInterruptFeature::enableInterrupts(uint16_t interruptMask) {
@@ -122,7 +122,7 @@ namespace stm32plus {
 
   /**
    * Disable the interrupts specified in the mask
-   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | OVERFLOW
+   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | ADC_OVERFLOW
    */
 
   inline void AdcInterruptFeature::disableInterrupts(uint16_t interruptMask) {

--- a/lib/include/adc/features/f4/AdcInterruptFeature.h
+++ b/lib/include/adc/features/f4/AdcInterruptFeature.h
@@ -43,7 +43,7 @@ namespace stm32plus {
       enum {
         END_OF_CONVERSION           = 0x01,
         INJECTED_END_OF_CONVERSION  = 0x02,
-        OVERFLOW                    = 0x04,
+        ADC_OVERFLOW                = 0x04,
         ANALOG_WATCHDOG             = 0x08
       };
 
@@ -95,7 +95,7 @@ namespace stm32plus {
 
   /**
    * Enable the interrupts specified in the mask
-   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | OVERFLOW
+   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | ADC_OVERFLOW
    */
 
   inline void AdcInterruptFeature::enableInterrupts(uint16_t interruptMask) {
@@ -111,14 +111,14 @@ namespace stm32plus {
       ADC_ITConfig(_adc,ADC_IT_JEOC,ENABLE);
     if((interruptMask & ANALOG_WATCHDOG)!=0)
       ADC_ITConfig(_adc,ADC_IT_AWD,ENABLE);
-    if((interruptMask & OVERFLOW)!=0)
+    if((interruptMask & ADC_OVERFLOW)!=0)
       ADC_ITConfig(_adc,ADC_IT_OVR,ENABLE);
   }
 
 
   /**
    * Disable the interrupts specified in the mask
-   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | OVERFLOW
+   * @param interruptMask The bitmask of interrupts, e.g. END_OF_CONVERSION | ADC_OVERFLOW
    */
 
   inline void AdcInterruptFeature::disableInterrupts(uint16_t interruptMask) {
@@ -130,7 +130,7 @@ namespace stm32plus {
       ADC_ITConfig(_adc,ADC_IT_JEOC,DISABLE);
     if((interruptMask & ANALOG_WATCHDOG)!=0)
       ADC_ITConfig(_adc,ADC_IT_AWD,DISABLE);
-    if((interruptMask & OVERFLOW)!=0)
+    if((interruptMask & ADC_OVERFLOW)!=0)
       ADC_ITConfig(_adc,ADC_IT_OVR,DISABLE);
   }
 }


### PR DESCRIPTION
…in STL.

Was having issues compiling with version 6.3.1 of newlib since `math.h` defines `OVERFLOW`.  Added the prefix of `ADC_` to the define to fix the issue.