### PR TITLE
Fix for the stm32plus::display::Font class.

### DIFF
--- a/lib/include/display/graphic/Font.h
+++ b/lib/include/display/graphic/Font.h
@@ -76,7 +76,7 @@ namespace stm32plus {
 
       ptr=nullptr;
 
-      if(character>=_firstCharacter && character<_lastCharacter) {
+      if(character>=_firstCharacter && character<=_lastCharacter) {
 
         // the character is in range and indexable, is it in sequential place?
 


### PR DESCRIPTION
FontBase::getCharacter(...) method ignores the last character code when searching for the character definition. It results in returning the first definition instead as a fallback.