### PR TITLE
I2c timeout fix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -16,8 +16,10 @@ Usage: scons mode=<MODE> mcu=<MCU> (hse=<HSE> / hsi=<HSI>) [float=hard] [example
     f1md   = STM32100 medium density series.
     f1mdvl = STM32100 medium density value line series.
     f4     = STM32F407/f417 series (maintained for backwards compatibility)
+    f401   = STM32F401
     f405   = STM32F405
     f407   = STM32F407
+    f411   = STM32F411
     f415   = STM32F417
     f417   = STM32F417
     f427   = STM32F427
@@ -184,8 +186,14 @@ elif mcu=="f1md":
 elif mcu=="f4" or mcu=="f407":
   setFlags("m4","F407")
   floatOpt()
+elif mcu=="f401":
+  setFlags("m4","F401")
+  floatOpt()
 elif mcu=="f405":
   setFlags("m4","F405")
+  floatOpt()
+elif mcu=="f411":
+  setFlags("m4","F411")
   floatOpt()
 elif mcu=="f415":
   setFlags("m4","F415")

--- a/lib/fwlib/f4/stdperiph/inc/stm32f4xx_adc.h
+++ b/lib/fwlib/f4/stdperiph/inc/stm32f4xx_adc.h
@@ -327,9 +327,7 @@ typedef struct
 
 #if defined (STM32F40_41xxx)
 #define ADC_Channel_TempSensor                      ((uint8_t)ADC_Channel_16)
-#endif /* STM32F40_41xxx */
-
-#if defined (STM32F427_437xx) || defined (STM32F429_439xx) || defined (STM32F401xx) || defined (STM32F411xE)
+#elif defined (STM32F427_437xx) || defined (STM32F429_439xx) || defined (STM32F401xx) || defined (STM32F411xE)
 #define ADC_Channel_TempSensor                      ((uint8_t)ADC_Channel_18)
 #endif /* STM32F427_437xx || STM32F429_439xx || STM32F401xx || STM32F411xE */
 

--- a/lib/fwlib/f4/stdperiph/inc/stm32f4xx_dac.h
+++ b/lib/fwlib/f4/stdperiph/inc/stm32f4xx_dac.h
@@ -37,6 +37,8 @@
 /* Includes ------------------------------------------------------------------*/
 #include "fwlib/f4/cmsis/Device/ST/STM32F4xx/Include/stm32f4xx.h"
 
+#if defined(STM32PLUS_F4_HAS_DCMI)
+
 /** @addtogroup STM32F4xx_StdPeriph_Driver
   * @{
   */
@@ -286,6 +288,8 @@ FlagStatus DAC_GetFlagStatus(uint32_t DAC_Channel, uint32_t DAC_FLAG);
 void DAC_ClearFlag(uint32_t DAC_Channel, uint32_t DAC_FLAG);
 ITStatus DAC_GetITStatus(uint32_t DAC_Channel, uint32_t DAC_IT);
 void DAC_ClearITPendingBit(uint32_t DAC_Channel, uint32_t DAC_IT);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/lib/fwlib/f4/stdperiph/inc/stm32f4xx_rng.h
+++ b/lib/fwlib/f4/stdperiph/inc/stm32f4xx_rng.h
@@ -37,6 +37,8 @@
 /* Includes ------------------------------------------------------------------*/
 #include "fwlib/f4/cmsis/Device/ST/STM32F4xx/Include/stm32f4xx.h"
 
+#if defined(STM32PLUS_F4_HAS_RNG)
+
 /** @addtogroup STM32F4xx_StdPeriph_Driver
   * @{
   */
@@ -102,6 +104,8 @@ FlagStatus RNG_GetFlagStatus(uint8_t RNG_FLAG);
 void RNG_ClearFlag(uint8_t RNG_FLAG);
 ITStatus RNG_GetITStatus(uint8_t RNG_IT);
 void RNG_ClearITPendingBit(uint8_t RNG_IT);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/lib/fwlib/f4/stdperiph/src/stm32f4xx_dac.c
+++ b/lib/fwlib/f4/stdperiph/src/stm32f4xx_dac.c
@@ -131,6 +131,8 @@
 #include "fwlib/f4/stdperiph/inc/stm32f4xx_dac.h"
 #include "fwlib/f4/stdperiph/inc/stm32f4xx_rcc.h"
 
+#if defined(STM32PLUS_F4_HAS_DCMI)
+
 /** @addtogroup STM32F4xx_StdPeriph_Driver
   * @{
   */
@@ -712,3 +714,5 @@ void DAC_ClearITPendingBit(uint32_t DAC_Channel, uint32_t DAC_IT)
   */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+#endif

--- a/lib/fwlib/f4/stdperiph/src/stm32f4xx_gpio.c
+++ b/lib/fwlib/f4/stdperiph/src/stm32f4xx_gpio.c
@@ -154,6 +154,7 @@ void GPIO_DeInit(GPIO_TypeDef* GPIOx)
     RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOE, ENABLE);
     RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOE, DISABLE);
   }
+#if defined (STM32PLUS_F4_HAS_GPIOF_G_I)
   else if (GPIOx == GPIOF)
   {
     RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOF, ENABLE);
@@ -175,9 +176,9 @@ void GPIO_DeInit(GPIO_TypeDef* GPIOx)
     RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOI, ENABLE);
     RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOI, DISABLE);
   }
+#endif
 
-#if defined(STM32PLUS_F427) || defined(STM32PLUS_F429) || defined(STM32PLUS_F437) || defined(STM32PLUS_F439)
-
+#if defined(STM32PLUS_F4_HAS_GPIOJ_K)
   else if (GPIOx == GPIOJ)
   {
     RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOJ, ENABLE);

--- a/lib/fwlib/f4/stdperiph/src/stm32f4xx_rng.c
+++ b/lib/fwlib/f4/stdperiph/src/stm32f4xx_rng.c
@@ -56,6 +56,8 @@
 #include "fwlib/f4/stdperiph/inc/stm32f4xx_rng.h"
 #include "fwlib/f4/stdperiph/inc/stm32f4xx_rcc.h"
 
+#if defined(STM32PLUS_F4_HAS_RNG)
+
 /** @addtogroup STM32F4xx_StdPeriph_Driver
   * @{
   */
@@ -393,5 +395,6 @@ void RNG_ClearITPendingBit(uint8_t RNG_IT)
   * @}
   */ 
 
-
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+#endif

--- a/lib/fwlib/f4/stdperiph/src/stm32f4xx_tim.c
+++ b/lib/fwlib/f4/stdperiph/src/stm32f4xx_tim.c
@@ -227,6 +227,7 @@ void TIM_DeInit(TIM_TypeDef* TIMx)
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM5, ENABLE);
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM5, DISABLE);
   }  
+#if defined (STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
   else if (TIMx == TIM6)  
   {    
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM6, ENABLE);
@@ -242,6 +243,7 @@ void TIM_DeInit(TIM_TypeDef* TIMx)
     RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM8, ENABLE);
     RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM8, DISABLE);  
   }  
+#endif
   else if (TIMx == TIM9)
   {      
     RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM9, ENABLE);
@@ -257,6 +259,7 @@ void TIM_DeInit(TIM_TypeDef* TIMx)
     RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM11, ENABLE);
     RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM11, DISABLE);  
   }  
+#if defined (STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
   else if (TIMx == TIM12)
   {      
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM12, ENABLE);
@@ -275,6 +278,7 @@ void TIM_DeInit(TIM_TypeDef* TIMx)
       RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM14, DISABLE); 
     }   
   }
+#endif
 }
 
 /**
@@ -296,21 +300,27 @@ void TIM_TimeBaseInit(TIM_TypeDef* TIMx, TIM_TimeBaseInitTypeDef* TIM_TimeBaseIn
 
   tmpcr1 = TIMx->CR1;  
 
-  if((TIMx == TIM1) || (TIMx == TIM8)||
-     (TIMx == TIM2) || (TIMx == TIM3)||
-     (TIMx == TIM4) || (TIMx == TIM5)) 
+  if((TIMx == TIM1) || (TIMx == TIM2) ||
+     (TIMx == TIM3) || (TIMx == TIM4) ||
+     (TIMx == TIM5) 
+#if defined (STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
+     || (TIMx == TIM8)
+#endif
+    )
   {
     /* Select the Counter Mode */
     tmpcr1 &= (uint16_t)(~(TIM_CR1_DIR | TIM_CR1_CMS));
     tmpcr1 |= (uint32_t)TIM_TimeBaseInitStruct->TIM_CounterMode;
   }
  
+#if defined (STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
   if((TIMx != TIM6) && (TIMx != TIM7))
   {
     /* Set the clock division */
     tmpcr1 &=  (uint16_t)(~TIM_CR1_CKD);
     tmpcr1 |= (uint32_t)TIM_TimeBaseInitStruct->TIM_ClockDivision;
   }
+#endif
 
   TIMx->CR1 = tmpcr1;
 
@@ -320,8 +330,12 @@ void TIM_TimeBaseInit(TIM_TypeDef* TIMx, TIM_TimeBaseInitTypeDef* TIM_TimeBaseIn
   /* Set the Prescaler value */
   TIMx->PSC = TIM_TimeBaseInitStruct->TIM_Prescaler;
     
-  if ((TIMx == TIM1) || (TIMx == TIM8))  
-  {
+  if ((TIMx == TIM1)
+#if defined (STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
+     || (TIMx == TIM8)
+#endif
+     )
+ {
     /* Set the Repetition Counter value */
     TIMx->RCR = TIM_TimeBaseInitStruct->TIM_RepetitionCounter;
   }
@@ -705,7 +719,11 @@ void TIM_OC1Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct)
   /* Set the Output State */
   tmpccer |= TIM_OCInitStruct->TIM_OutputState;
     
-  if((TIMx == TIM1) || (TIMx == TIM8))
+  if((TIMx == TIM1)
+#if defined (STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
+     || (TIMx == TIM8)
+#endif
+    )
   {
     assert_param(IS_TIM_OUTPUTN_STATE(TIM_OCInitStruct->TIM_OutputNState));
     assert_param(IS_TIM_OCN_POLARITY(TIM_OCInitStruct->TIM_OCNPolarity));
@@ -787,7 +805,11 @@ void TIM_OC2Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct)
   /* Set the Output State */
   tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 4);
     
-  if((TIMx == TIM1) || (TIMx == TIM8))
+  if((TIMx == TIM1)
+#if defined (STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
+     || (TIMx == TIM8)
+#endif
+    )
   {
     assert_param(IS_TIM_OUTPUTN_STATE(TIM_OCInitStruct->TIM_OutputNState));
     assert_param(IS_TIM_OCN_POLARITY(TIM_OCInitStruct->TIM_OCNPolarity));
@@ -867,7 +889,11 @@ void TIM_OC3Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct)
   /* Set the Output State */
   tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 8);
     
-  if((TIMx == TIM1) || (TIMx == TIM8))
+  if((TIMx == TIM1)
+#if defined (STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
+     || (TIMx == TIM8)
+#endif
+    )
   {
     assert_param(IS_TIM_OUTPUTN_STATE(TIM_OCInitStruct->TIM_OutputNState));
     assert_param(IS_TIM_OCN_POLARITY(TIM_OCInitStruct->TIM_OCNPolarity));
@@ -948,7 +974,11 @@ void TIM_OC4Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct)
   /* Set the Output State */
   tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 12);
   
-  if((TIMx == TIM1) || (TIMx == TIM8))
+  if((TIMx == TIM1)
+#if defined (STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
+     || (TIMx == TIM8)
+#endif
+    )
   {
     assert_param(IS_TIM_OCIDLE_STATE(TIM_OCInitStruct->TIM_OCIdleState));
     /* Reset the Output Compare IDLE State */

--- a/lib/fwlib/f4/stdperiph/src/stm32f4xx_usart.c
+++ b/lib/fwlib/f4/stdperiph/src/stm32f4xx_usart.c
@@ -199,6 +199,7 @@ void USART_DeInit(USART_TypeDef* USARTx)
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART2, ENABLE);
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART2, DISABLE);
   }
+#if defined(STM32PLUS_F4_HAS_USART3_4_5)
   else if (USARTx == USART3)
   {
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART3, ENABLE);
@@ -214,6 +215,7 @@ void USART_DeInit(USART_TypeDef* USARTx)
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_UART5, ENABLE);
     RCC_APB1PeriphResetCmd(RCC_APB1Periph_UART5, DISABLE);
   }  
+#endif
   else if (USARTx == USART6)
   {
     RCC_APB2PeriphResetCmd(RCC_APB2Periph_USART6, ENABLE);

--- a/lib/include/adc/features/f4/AdcChannelGpioInitialiser.h
+++ b/lib/include/adc/features/f4/AdcChannelGpioInitialiser.h
@@ -57,6 +57,7 @@ namespace stm32plus {
           case 15: port=GPIOC; pin=GPIO_Pin_5; break;
         }
       }
+#if defined(STM32PLUS_F4_HAS_ADC2_3)
       else if(TAdcNumber==2) {
         switch(TChannelNumber) {
           case 0: port=GPIOA; pin=GPIO_Pin_0; break;
@@ -97,7 +98,7 @@ namespace stm32plus {
           case 15: port=GPIOF; pin=GPIO_Pin_5; break;
         }
       }
-
+#endif
       // initialise the pin
 
       GpioPinInitialiser::initialise(port,pin);   // this minimal overload is for analog input

--- a/lib/include/config/adc.h
+++ b/lib/include/config/adc.h
@@ -51,8 +51,10 @@
   #include "adc/f4/Adc.h"
   #include "adc/f4/AdcPeripheral.h"
   #include "adc/Adc1.h"
+#if defined(STM32PLUS_F4_HAS_ADC2_3)
   #include "adc/Adc2.h"
   #include "adc/Adc3.h"
+#endif
 
 #endif
 

--- a/lib/include/config/dac.h
+++ b/lib/include/config/dac.h
@@ -24,9 +24,11 @@
 
 // peripheral includes
 
-#include "dac/Dac.h"
-#include "dac/DacPinInitialiser.h"
-#include "dac/DacPeripheral.h"
+#if defined(STM32PLUS_F4_HAS_DAC)
+  #include "dac/Dac.h"
+  #include "dac/DacPinInitialiser.h"
+  #include "dac/DacPeripheral.h"
+#endif
 
 // feature includes
 

--- a/lib/include/config/mcu_defines.h
+++ b/lib/include/config/mcu_defines.h
@@ -42,6 +42,13 @@
 #elif defined(STM32PLUS_F0_42)
   #define STM32PLUS_F0
   #define STM32F0XX
+
+#elif defined(STM32PLUS_F401)
+  #define STM32PLUS_F4
+  #define STM32F401xx
+  #define STM32F401xC
+  #define STM32F401xE
+
 #elif defined(STM32PLUS_F405)
   #define STM32PLUS_F4
   #define STM32F405xx
@@ -54,6 +61,7 @@
   #define STM32PLUS_F4_HAS_OTG_HS
   #define STM32PLUS_F4_HAS_DAC
   #define STM32PLUS_F4_HAS_FSMC
+  #define STM32PLUS_F4_HAS_RNG
 
 #elif defined(STM32PLUS_F407)
   #define STM32PLUS_F4
@@ -69,6 +77,11 @@
   #define STM32PLUS_F4_HAS_OTG_HS
   #define STM32PLUS_F4_HAS_DAC
   #define STM32PLUS_F4_HAS_FSMC
+  #define STM32PLUS_F4_HAS_RNG
+
+#elif defined(STM32PLUS_F411)
+  #define STM32PLUS_F4
+  #define STM32F411xE
 
 #elif defined(STM32PLUS_F415)
   #define STM32PLUS_F4
@@ -83,6 +96,7 @@
   #define STM32PLUS_F4_HAS_OTG_HS
   #define STM32PLUS_F4_HAS_DAC
   #define STM32PLUS_F4_HAS_FSMC
+  #define STM32PLUS_F4_HAS_RNG
 
 #elif defined(STM32PLUS_F417)
   #define STM32PLUS_F4
@@ -99,6 +113,7 @@
   #define STM32PLUS_F4_HAS_OTG_HS
   #define STM32PLUS_F4_HAS_DAC
   #define STM32PLUS_F4_HAS_FSMC
+  #define STM32PLUS_F4_HAS_RNG
 
 #elif defined(STM32PLUS_F427)
   #define STM32PLUS_F4
@@ -117,6 +132,7 @@
   #define STM32PLUS_F4_HAS_OTG_HS
   #define STM32PLUS_F4_HAS_DAC
   #define STM32PLUS_F4_HAS_FMC
+  #define STM32PLUS_F4_HAS_RNG
 
 #elif defined(STM32PLUS_F429)
   #define STM32PLUS_F4
@@ -136,6 +152,7 @@
   #define STM32PLUS_F4_HAS_OTG_HS
   #define STM32PLUS_F4_HAS_DAC
   #define STM32PLUS_F4_HAS_FMC
+  #define STM32PLUS_F4_HAS_RNG
 
 #elif defined(STM32PLUS_F437)
   #define STM32PLUS_F4
@@ -155,6 +172,7 @@
   #define STM32PLUS_F4_HAS_OTG_HS
   #define STM32PLUS_F4_HAS_DAC
   #define STM32PLUS_F4_HAS_FMC
+  #define STM32PLUS_F4_HAS_RNG
 
 #elif defined(STM32PLUS_F439)
   #define STM32PLUS_F4
@@ -175,6 +193,7 @@
   #define STM32PLUS_F4_HAS_OTG_HS
   #define STM32PLUS_F4_HAS_DAC
   #define STM32PLUS_F4_HAS_FMC
+  #define STM32PLUS_F4_HAS_RNG
 
 #else
   #error "You must define an MCU type. See config/stm32plus.h"

--- a/lib/include/config/rng.h
+++ b/lib/include/config/rng.h
@@ -24,11 +24,15 @@
 
 #if defined(STM32PLUS_F4)
 
+#if defined (STM32PLUS_F4_HAS_RNG)
+
 #define USE_RNG_INTERRUPT
 
 #include "rng/f4/Rng.h"
 #include "rng/f4/RngEventSource.h"
 #include "rng/f4/features/RngInterruptFeature.h"
+
+#endif
 
 #elif defined(STM32PLUS_F1)
 

--- a/lib/include/config/usart.h
+++ b/lib/include/config/usart.h
@@ -71,9 +71,11 @@
 
 #define USE_USART1_INTERRUPT
 #define USE_USART2_INTERRUPT
+#if !defined (STM32PLUS_F4) || defined(STM32PLUS_F4_HAS_USART3_4_5)
 #define USE_USART3_INTERRUPT
 #define USE_UART4_INTERRUPT
 #define USE_UART5_INTERRUPT
+#endif
 
 // device specific includes
 

--- a/lib/include/dma/features/PwmFadeTimerDmaFeature.h
+++ b/lib/include/dma/features/PwmFadeTimerDmaFeature.h
@@ -165,6 +165,7 @@ namespace stm32plus {
   template<uint32_t TPriority=DMA_Priority_High,uint32_t TDmaMode=DMA_Mode_Normal>
   using Timer5Channel4UpdatePwmFadeTimerDmaFeature = PwmFadeTimerDmaFeature<Timer5Ccr4DmaPeripheralInfo,TIM_DMA_Update,TPriority,TDmaMode>;
 
+#if defined(STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
   // TIM7
 
   template<uint32_t TPriority=DMA_Priority_High,uint32_t TDmaMode=DMA_Mode_Normal>
@@ -192,9 +193,11 @@ namespace stm32plus {
 
   template<uint32_t TPriority=DMA_Priority_High,uint32_t TDmaMode=DMA_Mode_Normal>
   using Timer8Channel4UpdatePwmFadeTimerDmaFeature = PwmFadeTimerDmaFeature<Timer8Ccr4DmaPeripheralInfo,TIM_DMA_Update,TPriority,TDmaMode>;
+#endif
 
 #endif
 
+#if defined(STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
   // TIM6
 
   template<uint32_t TPriority=DMA_Priority_High,uint32_t TDmaMode=DMA_Mode_Normal>
@@ -208,4 +211,5 @@ namespace stm32plus {
 
   template<uint32_t TPriority=DMA_Priority_High,uint32_t TDmaMode=DMA_Mode_Normal>
   using Timer6Channel4UpdatePwmFadeTimerDmaFeature = PwmFadeTimerDmaFeature<Timer6Ccr4DmaPeripheralInfo,TIM_DMA_Update,TPriority,TDmaMode>;
+#endif
 }

--- a/lib/include/dma/features/f4/DmaPeripheralInfo.h
+++ b/lib/include/dma/features/f4/DmaPeripheralInfo.h
@@ -103,9 +103,11 @@ namespace stm32plus {
 
   struct Usart1TxDmaPeripheralInfo : UsartDmaPeripheralInfo { enum { REGISTER_ADDRESS = USART1_BASE + __builtin_offsetof(USART_TypeDef,DR) }; };
   struct Usart2TxDmaPeripheralInfo : UsartDmaPeripheralInfo { enum { REGISTER_ADDRESS = USART2_BASE + __builtin_offsetof(USART_TypeDef,DR) }; };
+#if defined (STM32PLUS_F4_HAS_USART3_4_5)
   struct Usart3TxDmaPeripheralInfo : UsartDmaPeripheralInfo { enum { REGISTER_ADDRESS = USART3_BASE + __builtin_offsetof(USART_TypeDef,DR) }; };
   struct Uart4TxDmaPeripheralInfo : UsartDmaPeripheralInfo { enum { REGISTER_ADDRESS = UART4_BASE + __builtin_offsetof(USART_TypeDef,DR) }; };
   struct Uart5TxDmaPeripheralInfo : UsartDmaPeripheralInfo { enum { REGISTER_ADDRESS = UART5_BASE + __builtin_offsetof(USART_TypeDef,DR) }; };
+#endif
 
 #if defined(STM32PLUS_F4)
   struct Usart6TxDmaPeripheralInfo : UsartDmaPeripheralInfo { enum { REGISTER_ADDRESS = USART6_BASE + __builtin_offsetof(USART_TypeDef,DR) }; };

--- a/lib/include/i2c/f4/I2C2Remap.h
+++ b/lib/include/i2c/f4/I2C2Remap.h
@@ -15,7 +15,7 @@
 
 namespace stm32plus {
 
-
+#if defined(STM32PLUS_F4_HAS_GPIOF_G_I)
   /*
    * Remap #1 pin package:
    * (SCL,SDA) = (PF1,PF0)
@@ -45,7 +45,7 @@ namespace stm32plus {
         Features(static_cast<I2C&>(*this))... {
     }
   };
-
+#endif
 
   /*
    * Remap #2 pin package:

--- a/lib/include/timer/features/f4/Timer10GpioFeature.h
+++ b/lib/include/timer/features/f4/Timer10GpioFeature.h
@@ -19,10 +19,11 @@ namespace stm32plus {
     typedef gpio::PB8 TIM10_CH1_Pin;
   };
 
+#if defined (STM32PLUS_F4_HAS_GPIOF_G_I)
   struct TIM10_PinPackage_Remap_Full {
     typedef gpio::PF6 TIM10_CH1_Pin;
   };
-
+#endif
 
   /**
    * Initialise GPIO pins for this timer GPIO mode
@@ -64,11 +65,13 @@ namespace stm32plus {
     }
   };
 
+#if defined (STM32PLUS_F4_HAS_GPIOF_G_I)
   template<template<typename> class... Features>
   struct Timer10GpioFeature<TIMER_REMAP_FULL,Features...> : TimerFeatureBase,Features<TIM10_PinPackage_Remap_Full>... {
     Timer10GpioFeature(Timer& timer) : TimerFeatureBase(timer) {
     }
   };
+#endif
 
   /**
    * Custom structure to allow any pin mapping.

--- a/lib/include/timer/features/f4/Timer11GpioFeature.h
+++ b/lib/include/timer/features/f4/Timer11GpioFeature.h
@@ -19,10 +19,11 @@ namespace stm32plus {
     typedef gpio::PB9 TIM11_CH1_Pin;
   };
 
+#if defined (STM32PLUS_F4_HAS_GPIOF_G_I)
   struct TIM11_PinPackage_Remap_Full {
     typedef gpio::PF7 TIM11_CH1_Pin;
   };
-
+#endif
 
   /**
    * Initialise GPIO pins for this timer GPIO mode
@@ -64,11 +65,13 @@ namespace stm32plus {
     }
   };
 
+#if defined(STM32PLUS_F4_HAS_GPIOF_G_I)
   template<template<typename> class... Features>
   struct Timer11GpioFeature<TIMER_REMAP_FULL,Features...> : TimerFeatureBase,Features<TIM11_PinPackage_Remap_Full>... {
     Timer11GpioFeature(Timer& timer) : TimerFeatureBase(timer) {
     }
   };
+#endif
 
   /**
    * Custom structure to allow any pin mapping.

--- a/lib/include/timing/MicrosecondDelay.h
+++ b/lib/include/timing/MicrosecondDelay.h
@@ -40,13 +40,13 @@ namespace stm32plus {
       static void delay(uint16_t us);
   };
 
-
+#if defined (STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
   /**
    * Use the basic timer TIM6 as a default for doing the microsecond delay.
    */
 
   typedef MicrosecondDelayTemplate<Timer6<Timer6InternalClockFeature> > MicrosecondDelay;
-
+#endif
 
   /**
    * Template static member initialisation

--- a/lib/include/traits/f4/traits.h
+++ b/lib/include/traits/f4/traits.h
@@ -50,6 +50,7 @@ namespace stm32plus {
   typedef PeripheralTraits<PERIPHERAL_ADC3> Adc3PeripheralTraits;
 #endif
 
+#if defined(STM32PLUS_F4_HAS_CAN)
   template<>
   struct PeripheralTraits<PERIPHERAL_CAN1> {
     enum {
@@ -67,7 +68,9 @@ namespace stm32plus {
     };
   };
   typedef PeripheralTraits<PERIPHERAL_CAN2> Can2PeripheralTraits;
+#endif
 
+#if defined(STM32PLUS_F4_HAS_DAC)
   template<>
   struct PeripheralTraits<PERIPHERAL_DAC1> {
     enum {
@@ -83,6 +86,7 @@ namespace stm32plus {
     };
   };
   typedef PeripheralTraits<PERIPHERAL_DAC1> Dac1PeripheralTraits;
+#endif
 
   template<>
   struct PeripheralTraits<PERIPHERAL_GPIO> {

--- a/lib/include/usart/f4/Usart3.h
+++ b/lib/include/usart/f4/Usart3.h
@@ -11,6 +11,7 @@
 #error This class can only be used with the STM32F4 series
 #endif
 
+#if defined (STM32PLUS_F4_HAS_USART3_4_5)
 
 namespace stm32plus {
 
@@ -154,3 +155,5 @@ namespace stm32plus {
     }
   };
 }
+
+#endif

--- a/lib/include/usart/f4/Usart6.h
+++ b/lib/include/usart/f4/Usart6.h
@@ -38,14 +38,18 @@ namespace stm32plus {
     enum {
       Port_TX=GPIOC_BASE,
       Port_RX=GPIOC_BASE,
+#if defined(STM32PLUS_F4_HAS_GPIOF_G_I)
       Port_RTS=GPIOG_BASE,
       Port_CTS=GPIOC_BASE,
+#endif
       Port_CK=GPIOC_BASE,
 
       Pin_TX=GPIO_Pin_6,
       Pin_RX=GPIO_Pin_7,
+#if defined(STM32PLUS_F4_HAS_GPIOF_G_I)
       Pin_RTS=GPIO_Pin_8,
       Pin_CTS=GPIO_Pin_13,
+#endif
       Pin_CK=GPIO_Pin_8
     };
   };
@@ -65,6 +69,7 @@ namespace stm32plus {
     }
   };
 
+#if defined(STM32PLUS_F4_HAS_GPIOF_G_I)
 
   /*
    * Remap #1:
@@ -101,4 +106,6 @@ namespace stm32plus {
         Features(static_cast<Usart&>(*this))... {
     }
   };
+#endif
+
 }

--- a/lib/include/usart/features/f4/UsartInterruptFeature.h
+++ b/lib/include/usart/features/f4/UsartInterruptFeature.h
@@ -175,6 +175,7 @@ namespace stm32plus {
     Nvic::configureIrq(USART2_IRQn);
   }
 
+#if defined (STM32PLUS_F4_HAS_USART3_4_5)
   /**
    * Enabler specialisation, Usart 3
    */
@@ -204,7 +205,7 @@ namespace stm32plus {
     _forceLinkage=&UART5_IRQHandler;
     Nvic::configureIrq(UART5_IRQn);
   }
-
+#endif
 
   /**
    * Enabler specialisation, Usart 6

--- a/lib/src/can/interrupts/f4/Can1InterruptHandler.cpp
+++ b/lib/src/can/interrupts/f4/Can1InterruptHandler.cpp
@@ -8,6 +8,8 @@
 
 #if defined(STM32PLUS_F4)
 
+#if defined(STM32PLUS_F4_HAS_CAN)
+
 #include "config/can.h"
 
 
@@ -80,5 +82,7 @@ extern "C" {
 
 #endif
 }
+
+#endif
 
 #endif

--- a/lib/src/can/interrupts/f4/Can2InterruptHandler.cpp
+++ b/lib/src/can/interrupts/f4/Can2InterruptHandler.cpp
@@ -8,6 +8,8 @@
 
 #if defined(STM32PLUS_F4)
 
+#if defined(STM32PLUS_F4_HAS_CAN)
+
 #include "config/can.h"
 
 
@@ -80,5 +82,7 @@ extern "C" {
 
 #endif
 }
+
+#endif
 
 #endif

--- a/lib/src/gpio/f4/GpioPinInitialiser.cpp
+++ b/lib/src/gpio/f4/GpioPinInitialiser.cpp
@@ -90,10 +90,12 @@ namespace stm32plus {
                              port==GPIOC ? RCC_AHB1Periph_GPIOC :
                              port==GPIOD ? RCC_AHB1Periph_GPIOD :
                              port==GPIOE ? RCC_AHB1Periph_GPIOE :
+#if defined (STM32PLUS_F4_HAS_GPIOF_G_I)
                              port==GPIOF ? RCC_AHB1Periph_GPIOF :
                              port==GPIOG ? RCC_AHB1Periph_GPIOG :
-                             port==GPIOH ? RCC_AHB1Periph_GPIOH :
-                             RCC_AHB1Periph_GPIOI
+                             port==GPIOI ? RCC_AHB1Periph_GPIOI :
+#endif
+                             RCC_AHB1Periph_GPIOH
                              ,ENABLE);
 
       // initialise

--- a/lib/src/i2c/features/f1,f4/I2CMasterPollingFeature.cpp
+++ b/lib/src/i2c/features/f1,f4/I2CMasterPollingFeature.cpp
@@ -38,11 +38,7 @@ namespace stm32plus {
       // the last byte gets a NACK after it and before the STOP
 
       if(!count) {
-
-        __disable_irq();
         I2C_AcknowledgeConfig(_i2c,DISABLE);
-        I2C_GenerateSTOP(_i2c,ENABLE);
-        __enable_irq();
       }
 
       if(!checkEvent(I2C_EVENT_MASTER_BYTE_RECEIVED))
@@ -53,6 +49,8 @@ namespace stm32plus {
       *output++=I2C_ReceiveData(_i2c);
     }
 
+    I2C_GenerateSTOP(_i2c,ENABLE);
+    while(I2C_GetFlagStatus(_i2c, I2C_FLAG_BUSY));
     return true;
   }
 
@@ -158,6 +156,7 @@ namespace stm32plus {
     // send STOP condition
 
     I2C_GenerateSTOP(_i2c,ENABLE);
+    while(I2C_GetFlagStatus(_i2c, I2C_FLAG_BUSY));
     return true;
   }
 

--- a/lib/src/rng/f4/features/RngInterruptFeature.cpp
+++ b/lib/src/rng/f4/features/RngInterruptFeature.cpp
@@ -10,6 +10,7 @@
 
 #include "config/rng.h"
 
+#if defined(STM32PLUS_F4_HAS_RNG)
 
 using namespace stm32plus;
 
@@ -52,5 +53,6 @@ extern "C" {
 }
 
 
+#endif
 #endif
 #endif

--- a/lib/src/timer/f4/Timer6InterruptHandler.cpp
+++ b/lib/src/timer/f4/Timer6InterruptHandler.cpp
@@ -8,7 +8,7 @@
 #include "config/timer.h"
 
 
-#if defined(STM32PLUS_F4)
+#if defined(STM32PLUS_F4) && defined(STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
 
 using namespace stm32plus;
 

--- a/lib/src/timer/f4/Timer7InterruptHandler.cpp
+++ b/lib/src/timer/f4/Timer7InterruptHandler.cpp
@@ -8,7 +8,7 @@
 #include "config/timer.h"
 
 
-#if defined(STM32PLUS_F4)
+#if defined(STM32PLUS_F4) && defined(STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
 
 using namespace stm32plus;
 

--- a/lib/src/timer/f4/Timer8_12_13_14InterruptHandlers.cpp
+++ b/lib/src/timer/f4/Timer8_12_13_14InterruptHandlers.cpp
@@ -7,7 +7,7 @@
 #include "config/stm32plus.h"
 #include "config/timer.h"
 
-#if defined(STM32PLUS_F4)
+#if defined(STM32PLUS_F4) && defined(STM32PLUS_F4_HAS_TIM6_7_8_12_13_14)
 
 
 using namespace stm32plus;


### PR DESCRIPTION
I found an inconsistent behaviour of my code using I2C code.

The code for a I2C device with the STM32F401 worked fine with the full CPU speed, but when I slowed it down (changing the PLL settings in system.c accordingly), it started hanging on (and eventually timing out on line 48 of I2CMasterPollingFeature::readBytes() inside checkEvent(I2C_EVENT_MASTER_BYTE_RECEIVED). The behaviour was slightly different with "debug" and "fast" builds. It looked like it was a timing issue. During debugging I found, that after receiving the second last byte and after the "if (!count)" was entered, the checkEvent() never returned until the timeout kicked in.

This fix has been tested in all build configurations (debug, fast and small), with both, slow (8MHz) and full CPU speed on both STM32F401 and STM32F411 devices.